### PR TITLE
Remove comment counts for posts with zero comments

### DIFF
--- a/hacker_news.js
+++ b/hacker_news.js
@@ -22,11 +22,8 @@ async function removeUpvotes() {
     // Handle HNES.
     for (const e of document.getElementsByClassName('comments')) {
         if (e instanceof HTMLAnchorElement) {
-            // Don't overwrite posts with 0 comments and posts with new comments.
-            if (e.text != "0" && e.children.length == 0) {
-                e.style.fontSize = ".7rem";
-                e.innerText = "discuss";
-            }
+            e.style.fontSize = ".7rem";
+            e.innerText = "discuss";
         }
     }
 }


### PR DESCRIPTION
Closes #2 . A post that shows "0" draws more attention to itself, 
which defeats the purpose of demetricating HN